### PR TITLE
Show notification when credentials are wrong

### DIFF
--- a/background.js
+++ b/background.js
@@ -77,7 +77,12 @@ chrome.webRequest.onBeforeSendHeaders.addListener(function(details) {
 
 chrome.webRequest.onCompleted.addListener(function(details) {
     if (details.statusCode === 401) {
-        fetchToken();
+        chrome.notifications.create('failed', {
+            type: 'basic',
+            iconUrl: 'auth.png',
+            title: 'Authentication Failed',
+            message: 'Invalid login details, please check service url and credentials'
+        });
     }
 }, {"urls":["*://*/*"]});
 
@@ -91,6 +96,3 @@ chrome.commands.onCommand.addListener(function(command) {
 });
 
 init();
-
-
-

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": 2,
   "description": "Fetches periodically a new token from your configured Auth URL and passes it via the Authorization Header to configured URLs. Everything can be configured by the options page of this Chrome extension.",
   "icons": { "128": "auth.png" },
-  "permissions": ["storage", "webRequest", "*://*/*", "background", "webRequestBlocking", "alarms"],
+  "permissions": ["storage", "webRequest", "*://*/*", "background", "webRequestBlocking", "alarms", "notifications"],
   "background": {
     "scripts": ["background.js"],
     "persistent":true


### PR DESCRIPTION
If incorrect credentials are used against an endpoint, a notification is shown prompting the user to check their details.

Previously it was possible to end up in a ddos-like request loop against the service endpoint.